### PR TITLE
copyright only shows for specified content types

### DIFF
--- a/layouts/partials/copyright.html
+++ b/layouts/partials/copyright.html
@@ -1,4 +1,4 @@
-{{ if and (isset .Site.Params "cc")  (in .Site.Params.cc.types .Type) }}
+{{ if and (isset .Site.Params "cc")  (in (slice "post" "posts") .Type) }}
 <div class="post-archive">
     <ul class="post-copyright">
         <li><strong>原文作者：</strong><a rel="author" href="{{ .Site.BaseURL}}">{{ if isset .Site.Author "name" }}{{.Site.Author.name}}{{ else }}{{.Site.Title}}{{ end }}</a></li>

--- a/layouts/partials/copyright.html
+++ b/layouts/partials/copyright.html
@@ -1,4 +1,4 @@
-{{ if isset .Site.Params "cc" }}
+{{ if and (isset .Site.Params "cc")  (in .Site.Params.cc.types .Type) }}
 <div class="post-archive">
     <ul class="post-copyright">
         <li><strong>原文作者：</strong><a rel="author" href="{{ .Site.BaseURL}}">{{ if isset .Site.Author "name" }}{{.Site.Author.name}}{{ else }}{{.Site.Title}}{{ end }}</a></li>


### PR DESCRIPTION
配置方式如下
```toml
[params.cc]
    name = "知识共享署名-非商业性使用-禁止演绎 4.0 国际许可协议"
    link = "https://creativecommons.org/licenses/by-nc-nd/4.0/deed.zh"
    types = ["blog","posts"]
```
版权声明只在types规定的几种类型的content中显示，避免在about页面，以及其他不必须要的页面显示