### PR TITLE
增加重要缺失文件，否则新站点 /categories/ 和 /tags/ 无法访问

### DIFF
--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,0 +1,39 @@
+{{ partial "head" . }}
+
+<body>
+{{ partial "header" . }}
+
+<div id="body">
+    <div class="container">
+        <div class="col-group">
+
+            <div class="col-8" id="main">
+                <div class="res-cons">
+                    {{ if eq .Data.Singular "category" }}
+                    <h1>共有{{ len .Data.Terms }}个分类</h1>
+                    {{ else if eq .Data.Singular "tag" }}
+                    <h1>共有{{ len .Data.Terms }}个标签</h1>
+                    {{ end }}
+
+                    {{ range .Data.Terms.ByCount }}
+                    <h2><a href="{{ printf "/%s/%s" $.Data.Plural .Term | urlize }}">{{ .Term }}</a> ({{ .Count }})</h2>
+                    <ul>
+                        {{ range .Pages }}
+                        <li>
+                            <date class="meta-date">{{ .Date.Format "2006/01/02" }}</date>
+                            <a class="archive-title" href="{{ .Permalink }}">{{ .Title }}</a>
+                        </li>
+                        {{ end }}
+                    </ul>
+                    {{ end }}
+                </div>
+            </div>
+
+            {{ partial "sidebar" . }}
+        </div>
+    </div>
+</div>
+{{ partial "footer" . }}
+
+</body>
+</html>


### PR DESCRIPTION
我按说明使用你的主题新建站点，一切工作正常，但是 /categories/ 和 /tags/ 无法访问。public 目录的 /categories/ 和 /tags/ 也只有 index.xml 而没有 index.html。

Hugo 服务模式下，我多访问几次 /tags/ 的话，它就报错，说缺失文件。后来我从老的 maupassant 项目中找来了这个：`layouts/_default/terms.html` 才工作正常。