### PR TITLE
增加 GraphViz 矢量图，在 params 里面设置 viz=true 启用

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -31,10 +31,34 @@
 {{ template "_internal/google_analytics_async.html" . }}
 
 {{ if .Site.Params.busuanzi }}
-<script type="text/javascript" src="//busuanzi.ibruce.info/busuanzi/2.3/busuanzi.pure.mini.js" async></script>
+<script type="text/javascript" src="//busuanzi.ibruce.info/busuanzi/2.3/busuanzi.pure.mini.js" async></script>
 {{ end }}
 
 <!-- custom js -->
 {{ range .Site.Params.customJS }}
   <script src="{{ "/js/" | relURL }}{{ . }}"></script>
 {{ end }}
+
+<!-- graphviz renderring -->
+{{ if .Site.Params.viz}}
+	<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/viz.js/1.7.1/viz.js"> </script>
+	<script type="text/javascript">
+	(function(){
+		var vizPrefix = "language-viz-";
+		Array.prototype.forEach.call(document.querySelectorAll("[class^=" + vizPrefix + "]"), function(x){
+			var engine;
+			x.getAttribute("class").split(" ").forEach(function(cls){
+				if (cls.startsWith(vizPrefix)) {
+					engine = cls.substr(vizPrefix.length);
+				}
+			});
+			var image = new DOMParser().parseFromString(Viz(x.innerText, {format:"svg", engine:engine}), "image/svg+xml");
+			x.parentNode.insertBefore(image.documentElement, x);
+			x.style.display = 'none';
+			x.parentNode.style.backgroundColor = "white";
+			x.parentNode.style.border = "none";
+		});
+	})();
+	</script>
+{{ end }}
+

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -41,24 +41,30 @@
 
 <!-- graphviz renderring -->
 {{ if .Site.Params.viz}}
-	<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/viz.js/1.7.1/viz.js"> </script>
 	<script type="text/javascript">
-	(function(){
+	var script = document.createElement('script');
+	script.src = 'http://cdn.bootcss.com/viz.js/1.8.0/viz.js'; // 加载脚本路径
+	script.onload = function() {
 		var vizPrefix = "language-viz-";
-		Array.prototype.forEach.call(document.querySelectorAll("[class^=" + vizPrefix + "]"), function(x){
-			var engine;
+		Array.prototype.forEach.call(document.querySelectorAll("code"), function(x){
+			var engine = null;
 			x.getAttribute("class").split(" ").forEach(function(cls){
 				if (cls.startsWith(vizPrefix)) {
 					engine = cls.substr(vizPrefix.length);
 				}
 			});
-			var image = new DOMParser().parseFromString(Viz(x.innerText, {format:"svg", engine:engine}), "image/svg+xml");
-			x.parentNode.insertBefore(image.documentElement, x);
-			x.style.display = 'none';
-			x.parentNode.style.backgroundColor = "white";
-			x.parentNode.style.border = "none";
+			if (engine != null) {
+				var image = new DOMParser().parseFromString(Viz(x.innerText, {format:"svg", engine:engine}), "image/svg+xml");
+				x.parentNode.insertBefore(image.documentElement, x);
+				x.style.display = 'none';
+				x.parentNode.style.backgroundColor = "white";
+				x.parentNode.style.border = "none";
+			}
 		});
-	})();
+	};
+
+	document.body.appendChild(script);
+
 	</script>
 {{ end }}
 


### PR DESCRIPTION
1. 增加 GraphViz 矢量图，在 params 里面设置 viz=true 启用。
2. 修正 busuanzi URL 错误。

我是参考：https://zhoumingjun.github.io/2017/03/10/using-mathjax-and-graphviz-with-hugo 添加的 GraphViz 支持，大概用法就是：

使用 dot 引擎：

````
```viz-dot
digraph G {
       A -> B
       B -> C
       B -> D
}
```
````

效果：

![images1](https://user-images.githubusercontent.com/3035071/57172690-cd784e80-6e55-11e9-8a13-aec43431ab41.png)


使用 circo 引擎：

````
```viz-circo
digraph G {
       A -> B
       B -> C
       B -> D
}
```
````

效果：

![images2](https://user-images.githubusercontent.com/3035071/57172692-d5d08980-6e55-11e9-842f-c7897b2e8ff7.png)

复杂数据结构：

````
```viz-circo
digraph st2 {
 rankdir=TB;
  
 node [fontname = "Verdana", fontsize = 10, color="skyblue", shape="record"];
 edge [fontname = "Verdana", fontsize = 10, color="crimson", style="solid"];
  
 st_hash_type [label="{<head>st_hash_type|(*compare)|(*hash)}"];
 st_table_entry [label="{<head>st_table_entry|hash|key|record|<next>next}"];
 st_table [label="{st_table|<type>type|num_bins|num_entries|<bins>bins}"];
  
 st_table:bins -> st_table_entry:head;
 st_table:type -> st_hash_type:head;
 st_table_entry:next -> st_table_entry:head [style="dashed", color="forestgreen"];
}
```
````

效果：

![images3](https://user-images.githubusercontent.com/3035071/57172716-424b8880-6e56-11e9-8b09-393bbc42658a.png)


更多使用例子见：

https://graphviz.gitlab.io/gallery/
