### PR TITLE
hidden about page and hideen archives page in index page article

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -10,6 +10,7 @@
             <div class="col-8" id="main">
                 <div class="res-cons">
                     {{ range $index,$data := .Paginator.Pages }}
+		    {{ if not .Params.hidden }}
                         <article class="post">
                             <header>
                                 <h1 class="post-title">
@@ -32,6 +33,7 @@
                             </div>
                             <p class="readmore"><a href="{{ .Permalink }}">阅读全文</a></p>
                         </article>
+                    {{ end }}
                     {{ end }}
                     {{ partial "paginator" . }}
                 </div>


### PR DESCRIPTION
很喜欢这个主题，简洁大方，之前用 `typecho` 的时候就用了这个，搜索 `hugo themes` 看到大佬移植到了 `hugo` ，然后就开始折腾 `hugo` ，在此感谢大佬。
创建 `about` 、`archives` 单页的时候发现这两个页面也会显示在首页列表中。
这个 `PR` 可以把首页文章列表中的单页隐藏了
在不希望显示在首页文章列表中的单页面的 `Front Matter` 用加入 `hidden: true` 即可