### PR TITLE
fix: use {.Page.Title} get the original categories/tags value.

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,15 +227,11 @@ summaryLength = 140
   busuanzi = true
 ```
 
-#### 禁止分类的名称转为小写
+#### 关于分类的名称转为小写的问题
 
-我们在写文章的时候，会给文章进行分类，比如Golang，但是默认情况下，Hugo会把这个Golang转为小写，
-这就我们一直用原始字符的造成困扰，为了解决这个问题，Hugo提供了`preserveTaxonomyNames`配置，把它设置为`true`就可以了保持原来分类的名字了。
-
-```toml
-## 保持分类的原始名字（false会做转小写处理）
-preserveTaxonomyNames = true
-```
+`Hugo 0.55` 版本之前, 会有分类转成小写的问题，Hugo提供了`preserveTaxonomyNames`配置，把它设置为`true`就可以了保持原来分类的名字了。
+在 `Hugo 0.55` 这个版本，[hugo 移除了 preserveTaxonomyNames 配置](https://gohugo.io/content-management/taxonomies/#example-removing-default-taxonomies)，
+模板已经默认获取 tag 和 categories 的原始字符用来展示, 大小写的问题已经优雅的解决了。
 
 #### 禁止URL路径小写
 

--- a/layouts/partials/categories.html
+++ b/layouts/partials/categories.html
@@ -1,8 +1,6 @@
 <h3 class="widget-title">分类</h3>
 <ul class="widget-list">
-    {{ range $name, $taxonomy := .Site.Taxonomies.categories }}
-    <li>
-        <a href="{{ "/categories/" | absLangURL }}{{ $name | urlize }}/">{{ $name }}({{len $taxonomy}})</a>
-    </li>
+    {{ range .Site.Taxonomies.categories }}
+    <li><a href="{{ .Page.Permalink }}">{{ .Page.Title }} ({{ .Count }})</a></li>
     {{ end }}
 </ul>

--- a/layouts/partials/tags.html
+++ b/layouts/partials/tags.html
@@ -1,6 +1,6 @@
 <h3 class="widget-title">标签</h3>
 <div class="tagcloud">
-    {{ range $name, $taxonomy := .Site.Taxonomies.tags }}
-    <a href="{{ "/tags/" | absLangURL }}{{ $name | urlize }}/">{{ $name }}</a>
+    {{ range .Site.Taxonomies.tags }}
+    <a href="{{ .Page.Permalink }}">{{ .Page.Title }}</a>
     {{ end }}
 </div>


### PR DESCRIPTION
fixed #63 
gohugoio/hugo [#5719](https://github.com/gohugoio/hugo/issues/5719) 这个issue 在hugo 0.55 移除了`preserveTaxonomyNames`这个配置，并提供了新的方式获取原始字符 。